### PR TITLE
No guard cell computation using cfl for LLG compilation

### DIFF
--- a/Source/Parallelization/GuardCellManager.cpp
+++ b/Source/Parallelization/GuardCellManager.cpp
@@ -109,6 +109,7 @@ guardCellManager::Init (
     // Electromagnetic simulations: account for change in particle positions within half a time step
     // for current deposition and within one time step for charge deposition (since rho is needed
     // both at the beginning and at the end of the PIC iteration)
+#ifndef WARPX_MAG_LLG
     if (do_electrostatic == ElectrostaticSolverAlgo::None)
     {
         for (int i = 0; i < AMREX_SPACEDIM; i++)
@@ -117,7 +118,7 @@ guardCellManager::Init (
             ng_alloc_J[i]   += static_cast<int>(std::ceil(PhysConst::c * dt / dx[i] * 0.5_rt));
         }
     }
-
+#endif
     // Number of guard cells for local deposition of J and rho
     ng_depos_J   = ng_alloc_J;
     ng_depos_rho = ng_alloc_Rho;


### PR DESCRIPTION
The test-case in `Examples/Tests/Macroscopic_Maxwell/inputs_3d_LLG_original', performed only LLG without EM and therefore uses a large cfl to save computational time.
However, the  guard cells for `j` and `rho` are set using cfl, to ensure particles dont take a large step with a large cfl.
I have turned this computation off for our test cases, when `LLG=TRUE`, to ensure that we can run tests with large cfl, without running into the abort which checks if the number of guard cells < number of valid cells.
