### PR TITLE
 fix logic for new BC interface and remove support for old-interface

### DIFF
--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -183,30 +183,14 @@ void
 WarpX::InitPML ()
 {
 
-    // if periodicity defined in input, use existing pml interface
-    amrex::Vector<int> geom_periodicity(AMREX_SPACEDIM,0);
-    ParmParse pp_geometry("geometry");
-    if (pp_geometry.queryarr("is_periodic", geom_periodicity)) {
-        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-            if (geom_periodicity[idim] == 1) {
-                do_pml_Lo[idim] = 0;
-                do_pml_Hi[idim] = 0;
-            }
+    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+        if (WarpX::field_boundary_lo[idim] == FieldBoundaryType::PML) {
+            do_pml = 1;
+            do_pml_Lo[idim] = 1;
         }
-    } else {
-        // setting do_pml = 0 as default and turning it on only when user-input is set to PML.
-        do_pml = 0;
-        do_pml_Lo = amrex::IntVect::TheZeroVector();
-        do_pml_Hi = amrex::IntVect::TheZeroVector();
-        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-            if (WarpX::field_boundary_lo[idim] == FieldBoundaryType::PML) {
-                do_pml = 1;
-                do_pml_Lo[idim] = 1;
-            }
-            if (WarpX::field_boundary_hi[idim] == FieldBoundaryType::PML) {
-                do_pml = 1;
-                do_pml_Hi[idim] = 1;
-            }
+        if (WarpX::field_boundary_hi[idim] == FieldBoundaryType::PML) {
+            do_pml = 1;
+            do_pml_Hi[idim] = 1;
         }
     }
     if (finest_level > 0) do_pml = 1;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1223,7 +1223,7 @@ private:
     amrex::Vector<std::unique_ptr<amrex::MultiFab> > charge_buf;
 
     // PML
-    int do_pml = 1;
+    int do_pml = 0;
     int do_silver_mueller = 0;
     int pml_ncell = 10;
     int pml_delta = 10;
@@ -1232,8 +1232,8 @@ private:
     int do_pml_in_domain = 0;
     bool do_pml_dive_cleaning; // default set in WarpX.cpp
     bool do_pml_divb_cleaning; // default set in WarpX.cpp
-    amrex::IntVect do_pml_Lo = amrex::IntVect::TheUnitVector();
-    amrex::IntVect do_pml_Hi = amrex::IntVect::TheUnitVector();
+    amrex::IntVect do_pml_Lo = amrex::IntVect::TheZeroVector();
+    amrex::IntVect do_pml_Hi = amrex::IntVect::TheZeroVector();
     amrex::Vector<std::unique_ptr<PML> > pml;
 
     amrex::Real moving_window_x = std::numeric_limits<amrex::Real>::max();


### PR DESCRIPTION
This PR removed support for old boundary interface and keep only the new BC interface.
The same changes will be made in WarpX/development when all the boundary conditions are implemented and the new interface is used.

When pec is selected as the boundary condition, the code was still initializing PML layers, although not performing pml boundary condition. But, the intialization of these pml layers is not required, and therefore, I  am makind do_pml flags as false by default. 
These flags will be set to true only when FieldBoundaryType is PML, defined in the input as 
boundary.field_lo and boundary.field_hi.

