### PR TITLE
include what we use

### DIFF
--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -13,6 +13,7 @@
 #ifdef WARPX_USE_PSATD
 #   include "FieldSolver/SpectralSolver/SpectralFieldData.H"
 #endif
+#include "FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXProfilerWrapper.H"

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveHPML.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveHPML.cpp
@@ -16,6 +16,7 @@
 #endif
 #include "BoundaryConditions/PMLComponent.H"
 #include <AMReX_Gpu.H>
+#include <AMReX_MultiFab.H>
 #include <AMReX.H>
 
 using namespace amrex;

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveEPML.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveEPML.cpp
@@ -1,5 +1,6 @@
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H"
+#include "FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H"
 #ifdef WARPX_DIM_RZ
 #   include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H"
 #else

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveHM.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveHM.cpp
@@ -10,6 +10,7 @@
 #include "FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H"
 #include "FiniteDifferenceAlgorithms/CartesianCKCAlgorithm.H"
 #include "FiniteDifferenceAlgorithms/CartesianNodalAlgorithm.H"
+#include "FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H"
 #endif
 #include "Utils/WarpXConst.H"
 #include "Utils/CoarsenIO.H"

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveHM_2nd.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveHM_2nd.cpp
@@ -6,6 +6,7 @@ blank
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "FiniteDifferenceSolver.H"
 #include "FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H"
+#include "FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H"
 
 #include "Utils/WarpXConst.H"
 #include "Utils/CoarsenIO.H"

--- a/Source/FieldSolver/WarpXExternalEMFields.cpp
+++ b/Source/FieldSolver/WarpXExternalEMFields.cpp
@@ -3,6 +3,7 @@
 #include "Utils/WarpXUtil.H"
 #include "Parser/WarpXParserWrapper.H"
 #include "Parser/GpuParser.H"
+#include <AMReX_MultiFab.H>
 
 using namespace amrex;
 


### PR DESCRIPTION
In WarpX, PR : https://github.com/ECP-WarpX/WarpX/pull/1947 includes what we specifically use in each file instead of using forward declaration.

In this PR, specific header files are included in the files in artermis (not in WarpX) to ensure that the code compiles after merging WarpX/development.



