### PR TITLE
fix typo in macro init

### DIFF
--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -359,11 +359,10 @@ MacroscopicProperties::InitializeMacroMultiFabUsingParser (
     const auto dx_lev = warpx.Geom(lev).CellSizeArray();
     const RealBox& real_box = warpx.Geom(lev).ProbDomain();
     IntVect iv = macro_mf->ixType().toIntVect();
-    IntVect grown_iv = macro_mf->nGrowVect();
     for ( MFIter mfi(*macro_mf, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
         // Initialize ghost cells in addition to valid cells
 
-        const Box& tb = mfi.tilebox(grown_iv, macro_mf->nGrowVect());
+        const Box& tb = mfi.tilebox(iv, macro_mf->nGrowVect());
         auto const& macro_fab =  macro_mf->array(mfi);
         amrex::ParallelFor (tb,
             [=] AMREX_GPU_DEVICE (int i, int j, int k) {

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -361,7 +361,6 @@ MacroscopicProperties::InitializeMacroMultiFabUsingParser (
     IntVect iv = macro_mf->ixType().toIntVect();
     for ( MFIter mfi(*macro_mf, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
         // Initialize ghost cells in addition to valid cells
-
         const Box& tb = mfi.tilebox(iv, macro_mf->nGrowVect());
         auto const& macro_fab =  macro_mf->array(mfi);
         amrex::ParallelFor (tb,


### PR DESCRIPTION
Fixng the box used to initialize macroscopic parameters.
this is the same as the PR in Warpx
https://github.com/ECP-WarpX/WarpX/pull/2175
Instead of doing the following
`const Box& tb = mfi.tilebox(iv, macro_mf->nGrowVect());`
I had essentially done
`const Box& tb = mfi.tilebox(grown_iv, macro_mf->nGrowVect());`
where `grown_iv = macro_mf->nGrowVect()`