### PR TITLE
Internal pec extended to pml

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1433,7 +1433,21 @@ External fields
     field component is updated with the contribution from the `excitation_grid_function`
     of the corresponding field component.
     Constants required in the mathematical expression can be set using ``my_constants``.
-    This function is currently supported only for 3D simulations.
+    This function is currently supported only for 3D simulations and only for single-level simulations.
+    Note that by default the parser applies these functions to the electric fields only in the valid region
+    or in the regions specified by the user-defined parser.
+    The same function can also be applied to the fields in the pml region by setting
+    ``warpx.Apply_E_excitation_in_pml_region``.
+
+* ``Apply_E_excitation_in_pml_region`` (integer `0` or `1`) optional (default is `0`)
+    This parameter is used only if `E_excitation_on_grid_style` is set in the input.
+    If set to `1`, the excitation function for Ex, Ey, Ez set using
+    ``warpx.Ex_excitation_grid_function(x,y,z,t)``,
+    ``warpx.Ey_excitation_grid_function(x,y,z,t)``,
+    ``warpx.Ez_excitation_grid_function(x,y,z,t)`` will be applied to the electric fields defined
+    in the pml region. Note that, the pml region is set outside the domain boundary.
+    So for this feature to work as intended, it is essential that the parser function covers the pml
+    region.
 
 * ``H_excitation_on_grid_style`` (string) optional (default is "default")
     This parameter is used to set the type of external magnetic field excitation

--- a/Source/BoundaryConditions/PML.H
+++ b/Source/BoundaryConditions/PML.H
@@ -147,6 +147,11 @@ public:
     std::array<amrex::MultiFab*,3> GetH_fp ();
     std::array<amrex::MultiFab*,3> GetH_cp ();
 #endif
+    /**
+     * Returns component, 'comp', of the Efield in the pml region.
+     * \param[in] comp component of the Efield (0 for Ex, 1 for Ey, 2 for Ez)
+     */
+    amrex::MultiFab* GetE_fp (int comp);
 
     // Used when WarpX::do_pml_dive_cleaning = true
     amrex::MultiFab* GetF_fp ();

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -1114,6 +1114,12 @@ PML::GetE_fp ()
     return {pml_E_fp[0].get(), pml_E_fp[1].get(), pml_E_fp[2].get()};
 }
 
+amrex::MultiFab*
+PML::GetE_fp (int comp)
+{
+    return pml_E_fp[comp].get();
+}
+
 std::array<MultiFab*,3>
 PML::GetB_fp ()
 {

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -507,6 +507,10 @@ WarpX::OneStep_nosub (Real cur_time)
         FillBoundaryE(guard_cells.ng_FieldSolver);
         // ApplyExternalFieldExcitation
         ApplyExternalFieldExcitationOnGrid(ExternalFieldType::EfieldExternal); // apply E external excitation; soft source to be fixed
+        if (WarpX::ApplyExcitationInPML == 1) {
+            // Apply Efiled excitation in the pml region
+            ApplyExternalFieldExcitationOnGrid(ExternalFieldType::EfieldExternalPML);
+        }
 
         EvolveF(0.5_rt * dt[0], DtType::SecondHalf);
         EvolveG(0.5_rt * dt[0], DtType::SecondHalf);

--- a/Source/FieldSolver/WarpXExternalEMFields.cpp
+++ b/Source/FieldSolver/WarpXExternalEMFields.cpp
@@ -1,4 +1,5 @@
 #include "WarpX.H"
+#include "BoundaryConditions/PML.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXUtil.H"
 #include <AMReX_MultiFab.H>
@@ -30,6 +31,22 @@ WarpX::ApplyExternalFieldExcitationOnGrid (int const externalfieldtype)
                                                    Eyfield_flag_parser->compile<3>(),
                                                    Ezfield_flag_parser->compile<3>(),
                                                    lev );
+                // The excitation, especially when used to set an internal PEC, will be extended
+                // to the PML region with user-defined parser.
+                // As clarified in the documentation, it is upto the user to ensure that the parser
+                // is set up correctly if this default behavior is not needed.
+                if (WarpX::isAnyBoundaryPML() and externalfieldtype == ExternalFieldType::EfieldExternalPML) {
+                    ApplyExternalFieldExcitationOnGrid(pml[lev]->GetE_fp(0),
+                                                       pml[lev]->GetE_fp(1),
+                                                       pml[lev]->GetE_fp(2),
+                                                       Exfield_xt_grid_parser->compile<4>(),
+                                                       Eyfield_xt_grid_parser->compile<4>(),
+                                                       Ezfield_xt_grid_parser->compile<4>(),
+                                                       Exfield_flag_parser->compile<3>(),
+                                                       Eyfield_flag_parser->compile<3>(),
+                                                       Ezfield_flag_parser->compile<3>(),
+                                                       lev );
+                }
             }
         }
         if (externalfieldtype == ExternalFieldType::AllExternal || externalfieldtype == ExternalFieldType::BfieldExternal) {

--- a/Source/FieldSolver/WarpXExternalEMFields.cpp
+++ b/Source/FieldSolver/WarpXExternalEMFields.cpp
@@ -31,10 +31,13 @@ WarpX::ApplyExternalFieldExcitationOnGrid (int const externalfieldtype)
                                                    Eyfield_flag_parser->compile<3>(),
                                                    Ezfield_flag_parser->compile<3>(),
                                                    lev );
+            }
+        }
                 // The excitation, especially when used to set an internal PEC, will be extended
                 // to the PML region with user-defined parser.
                 // As clarified in the documentation, it is important that the parser is valid in the pml region
-                if (WarpX::isAnyBoundaryPML() and externalfieldtype == ExternalFieldType::EfieldExternalPML) {
+        if (WarpX::isAnyBoundaryPML() and externalfieldtype == ExternalFieldType::EfieldExternalPML) {
+            if (E_excitation_grid_s == "parse_e_excitation_grid_function") {
                     ApplyExternalFieldExcitationOnGrid(pml[lev]->GetE_fp(0),
                                                        pml[lev]->GetE_fp(1),
                                                        pml[lev]->GetE_fp(2),
@@ -45,7 +48,6 @@ WarpX::ApplyExternalFieldExcitationOnGrid (int const externalfieldtype)
                                                        Eyfield_flag_parser->compile<3>(),
                                                        Ezfield_flag_parser->compile<3>(),
                                                        lev );
-                }
             }
         }
         if (externalfieldtype == ExternalFieldType::AllExternal || externalfieldtype == ExternalFieldType::BfieldExternal) {

--- a/Source/FieldSolver/WarpXExternalEMFields.cpp
+++ b/Source/FieldSolver/WarpXExternalEMFields.cpp
@@ -33,8 +33,7 @@ WarpX::ApplyExternalFieldExcitationOnGrid (int const externalfieldtype)
                                                    lev );
                 // The excitation, especially when used to set an internal PEC, will be extended
                 // to the PML region with user-defined parser.
-                // As clarified in the documentation, it is upto the user to ensure that the parser
-                // is set up correctly if this default behavior is not needed.
+                // As clarified in the documentation, it is important that the parser is valid in the pml region
                 if (WarpX::isAnyBoundaryPML() and externalfieldtype == ExternalFieldType::EfieldExternalPML) {
                     ApplyExternalFieldExcitationOnGrid(pml[lev]->GetE_fp(0),
                                                        pml[lev]->GetE_fp(1),

--- a/Source/FieldSolver/WarpXExternalEMFields.cpp
+++ b/Source/FieldSolver/WarpXExternalEMFields.cpp
@@ -33,9 +33,9 @@ WarpX::ApplyExternalFieldExcitationOnGrid (int const externalfieldtype)
                                                    lev );
             }
         }
-                // The excitation, especially when used to set an internal PEC, will be extended
-                // to the PML region with user-defined parser.
-                // As clarified in the documentation, it is important that the parser is valid in the pml region
+        // The excitation, especially when used to set an internal PEC, will be extended
+        // to the PML region with user-defined parser.
+        // As clarified in the documentation, it is important that the parser is valid in the pml region
         if (WarpX::isAnyBoundaryPML() and externalfieldtype == ExternalFieldType::EfieldExternalPML) {
             if (E_excitation_grid_s == "parse_e_excitation_grid_function") {
                     ApplyExternalFieldExcitationOnGrid(pml[lev]->GetE_fp(0),

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -517,6 +517,8 @@ WarpX::InitLevelData (int lev, Real /*time*/)
                    makeParser(str_Ey_excitation_flag_function,{"x","y","z"}));
         Ezfield_flag_parser = std::make_unique<amrex::Parser>(
                    makeParser(str_Ez_excitation_flag_function,{"x","y","z"}));
+
+        pp_warpx.query("Apply_E_excitation_in_pml_region", ApplyExcitationInPML);
     }
     if (B_excitation_grid_s == "parse_b_excitation_grid_function") {
         // if B excitation type is set to parser then the corresponding

--- a/Source/Utils/WarpXAlgorithmSelection.H
+++ b/Source/Utils/WarpXAlgorithmSelection.H
@@ -130,6 +130,7 @@ struct ExternalFieldType {
         HfieldExternal = 3,
         HbiasfieldExternal = 4
 #endif
+        EfieldExternalPML = 5
     };
 };
 

--- a/Source/Utils/WarpXAlgorithmSelection.H
+++ b/Source/Utils/WarpXAlgorithmSelection.H
@@ -128,7 +128,7 @@ struct ExternalFieldType {
         BfieldExternal = 2,
 #ifdef WARPX_MAG_LLG
         HfieldExternal = 3,
-        HbiasfieldExternal = 4
+        HbiasfieldExternal = 4,
 #endif
         EfieldExternalPML = 5
     };

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -186,7 +186,7 @@ public:
     static std::string M_ext_grid_s; // added for M;
     static std::string H_bias_ext_grid_s;
 #endif
-
+    static int ApplyExcitationInPML;
     // Parser for B_external on the grid
     static std::string str_Bx_ext_grid_function;
     static std::string str_By_ext_grid_function;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -91,6 +91,7 @@ Vector<Real> WarpX::H_bias_external_grid(3, 0.0);
 std::string WarpX::authors = "";
 std::string WarpX::B_ext_grid_s = "default";
 std::string WarpX::E_ext_grid_s = "default";
+int WarpX::ApplyExcitationInPML = 0; // default is 0
 
 // default type is constant
 std::string WarpX::B_excitation_grid_s = "default";


### PR DESCRIPTION
When we use excitation as a hard source to set an internal PEC, we would need to extend this excitation in the PML region.

This can be done by adding an input 
`warpx.Apply_E_excitation_in_pml_region = 1`
This value is 0 by default

As noted in the documentation, the values will be updated in the pml region, ONLY if the user-defined function is spatially valid in that region.

I am wondering if this would solve Saurabh's issue ?
