### PR TITLE
Fix e surface integral normal and include multiplier vector

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2496,7 +2496,7 @@ Reduced Diagnostics
            The surface on which the surface integration is required. It must be either ``x``, ``y`` or ``z``.
            The direction of the normal is positive in the Cartesian directions.
 
-        * ``<reduced_diags_name>.multiplier_vector`` (`string`) optional (default `1 1 1`)
+        * ``<reduced_diags_name>.scaling_factor`` (`string`) optional (default `1 1 1`)
            This parameter is used when the ``integration_type`` is set to ``surface``. The parser takes three values to scale                      
            the reduced field quantities, namely, the surface integral of Ex, Ey, and Ez. 
            This parameter can be used in the following two scenarios:

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2489,7 +2489,7 @@ Reduced Diagnostics
            from z=-Lz/2 to 0, where Lz is the length of the domain in the z-direction spanning from -Lz/2 to Lz/2, as follows:
 
            ``<reduced_diags_name>.reduced_function(x,y,z) = " (y > y_plane_location - dy/2.-epsilon) * (y < y_plane_location+epsilon) * (z > -Lz/2.) * (z < 0.+epsilon) * 1 "``
-           
+
            In this example, epsilon is a very small number which is larger than machine precision.
 
         * ``<reduced_diags_name>.surface_normal`` (`string`)
@@ -2497,8 +2497,8 @@ Reduced Diagnostics
            The direction of the normal is positive in the Cartesian directions.
 
         * ``<reduced_diags_name>.scaling_factor`` (`string`) optional (default `1 1 1`)
-           This parameter is used when the ``integration_type`` is set to ``surface``. The parser takes three values to scale                      
-           the reduced field quantities, namely, the surface integral of Ex, Ey, and Ez. 
+           This parameter is used when the ``integration_type`` is set to ``surface``. The parser takes three values to scale
+           the reduced field quantities, namely, the surface integral of Ex, Ey, and Ez.
            This parameter can be used in the following two scenarios:
            Let's say, we require the surface integral of Ex on a surface, with the surface normal in the negative x-direction.
            In that case, we would specify the value of this parameter as ``-1 1 1`` so that the surface integral of Ex is multiplied by ``-1``.

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2488,7 +2488,9 @@ Reduced Diagnostics
            For example, we can define a surface on a y-plane at a location, `y_plane_location`, having a half cross-section
            from z=-Lz/2 to 0, where Lz is the length of the domain in the z-direction spanning from -Lz/2 to Lz/2, as follows:
 
-           ``<reduced_diags_name>.reduced_function(x,y,z) = " (y >= y_plane_location - dy/2.) * (y <= y_plane_location) * (z > -Lz/2.) * (z <= 0.) * 1 "``
+           ``<reduced_diags_name>.reduced_function(x,y,z) = " (y > y_plane_location - dy/2.-epsilon) * (y < y_plane_location+epsilon) * (z > -Lz/2.) * (z < 0.+epsilon) * 1 "``
+           
+           In this example, epsilon is very small number which is larger than machine precision.
 
         * ``<reduced_diags_name>.surface_normal`` (`string`)
            The surface on which the surface integration is required. It must be either ``x``, ``y`` or ``z``.

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2493,8 +2493,17 @@ Reduced Diagnostics
         * ``<reduced_diags_name>.surface_normal`` (`string`)
            The surface on which the surface integration is required. It must be either ``x``, ``y`` or ``z``.
            The direction of the normal is positive in the Cartesian directions.
-           Note that the user must account for the sign, if the outward normal of the defined surface is
-           in the negative direction.
+
+        * ``<reduced_diags_name>.multiplier_vector`` (`string`)
+           This parameter is optional, is only used when the ``integration_type`` is ``surface``, and takes three values which are
+           multiplied to Ex, Ey, and Ez, respectively, before outputting the their surface integral. The default values are ``1 1 1``.
+           This parameter can be used in the following two scenarios:
+           Let's say, we require the surface integral of Ex on a surface having normal pointing in the negative x-direction.
+           In that case, we would specify the value of this parameter as ``-1 1 1`` so that the surface integral of Ex is multiplied by ``-1``.
+           As another example, we may require a line integral which is obtained by first taking surface integral 
+           over a surface of height h and width w and then dividing by the width.
+           In this case we may specify the value of these parameters as ``1./w 1./w, 1./w``.
+
 
     * ``ParticleNumber``
         This type computes the total number of macroparticles and of physical particles (i.e. the

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2496,7 +2496,7 @@ Reduced Diagnostics
            The surface on which the surface integration is required. It must be either ``x``, ``y`` or ``z``.
            The direction of the normal is positive in the Cartesian directions.
 
-        * ``<reduced_diags_name>.multiplier_vector`` (`string`)
+        * ``<reduced_diags_name>.multiplier_vector`` (`string`) optional (default `1 1 1`)
            This parameter is used when the ``integration_type`` is set to ``surface``. The parser takes three values to scale                      
            the reduced field quantities, namely, the surface integral of Ex, Ey, and Ez. 
            This parameter can be used in the following two scenarios:

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2490,7 +2490,7 @@ Reduced Diagnostics
 
            ``<reduced_diags_name>.reduced_function(x,y,z) = " (y > y_plane_location - dy/2.-epsilon) * (y < y_plane_location+epsilon) * (z > -Lz/2.) * (z < 0.+epsilon) * 1 "``
            
-           In this example, epsilon is very small number which is larger than machine precision.
+           In this example, epsilon is a very small number which is larger than machine precision.
 
         * ``<reduced_diags_name>.surface_normal`` (`string`)
            The surface on which the surface integration is required. It must be either ``x``, ``y`` or ``z``.

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2500,7 +2500,7 @@ Reduced Diagnostics
            This parameter can be used in the following two scenarios:
            Let's say, we require the surface integral of Ex on a surface having normal pointing in the negative x-direction.
            In that case, we would specify the value of this parameter as ``-1 1 1`` so that the surface integral of Ex is multiplied by ``-1``.
-           As another example, we may require a line integral which is obtained by first taking surface integral 
+           As another example, we may require a line integral which is obtained by first taking surface integral
            over a surface of height h and width w and then dividing by the width.
            In this case we may specify the value of these parameters as ``1./w 1./w, 1./w``.
 

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2497,14 +2497,15 @@ Reduced Diagnostics
            The direction of the normal is positive in the Cartesian directions.
 
         * ``<reduced_diags_name>.multiplier_vector`` (`string`)
-           This parameter is optional, is only used when the ``integration_type`` is ``surface``, and takes three values which are
-           multiplied to Ex, Ey, and Ez, respectively, before outputting the their surface integral. The default values are ``1 1 1``.
+           This parameter is used when the ``integration_type`` is set to ``surface``. The parser takes three values to scale                      
+           the reduced field quantities, namely, the surface integral of Ex, Ey, and Ez. 
            This parameter can be used in the following two scenarios:
-           Let's say, we require the surface integral of Ex on a surface having normal pointing in the negative x-direction.
+           Let's say, we require the surface integral of Ex on a surface, with the surface normal in the negative x-direction.
            In that case, we would specify the value of this parameter as ``-1 1 1`` so that the surface integral of Ex is multiplied by ``-1``.
            As another example, we may require a line integral which is obtained by first taking surface integral
            over a surface of height h and width w and then dividing by the width.
-           In this case we may specify the value of these parameters as ``1./w 1./w, 1./w``.
+           In this case, we may specify the value of these parameters as ``1./w 1./w, 1./w``. Note that this can only be done
+           for a uniform grid simulation.
 
 
     * ``ParticleNumber``

--- a/Source/Diagnostics/ReducedDiags/RawEFieldReduction.H
+++ b/Source/Diagnostics/ReducedDiags/RawEFieldReduction.H
@@ -62,11 +62,16 @@ private:
     int m_reduction_type;
     // Type of integration (e.g. volume or surface)
     int m_integral_type;
-    // The direction of the surface for surface integration. (e.g. X, Y, or Z)
 #if (AMREX_SPACEDIM==2)
+    // The direction of the surface for surface integration. (e.g. X or Z)
     int m_surface_normal[2]={0,0};
+    // Multipliers for Ex and Ez surface integrals; default values of 1.0
+    std::vector<amrex::Real> m_multiplier_vector={1.0,1.0};
 #else
+    // The direction of the surface for surface integration. (e.g. X, Y, or Z)
     int m_surface_normal[3]={0,0,0};
+    // Multipliers for Ex, Ey, and Ez surface integrals; default values of 1.0
+    std::vector<amrex::Real> m_multiplier_vector={1.0,1.0,1.0};
 #endif
 
 public:
@@ -261,14 +266,14 @@ public:
                 } else {
 #if (AMREX_SPACEDIM==2)
                 amrex::Real length = surface_normal[0]*dx[1] + surface_normal[1]*dx[0];
-                reducedEx_value *= length;
+                reducedEx_value *= m_multiplier_vector[0]*length;
                 reducedEy_value *= length;
-                reducedEz_value *= length;
+                reducedEz_value *= m_multiplier_vector[1]*length;
 #else
                 amrex::Real area = surface_normal[0]*dx[1]*dx[2] + surface_normal[1]*dx[2]*dx[0] + surface_normal[2]*dx[0]*dx[1];
-                reducedEx_value *= area;
-                reducedEy_value *= area;
-                reducedEz_value *= area;
+                reducedEx_value *= m_multiplier_vector[0]*area;
+                reducedEy_value *= m_multiplier_vector[1]*area;
+                reducedEz_value *= m_multiplier_vector[2]*area;
 #endif
                 }
             }

--- a/Source/Diagnostics/ReducedDiags/RawEFieldReduction.H
+++ b/Source/Diagnostics/ReducedDiags/RawEFieldReduction.H
@@ -66,12 +66,12 @@ private:
     // The direction of the surface for surface integration. (e.g. X or Z)
     int m_surface_normal[2]={0,0};
     // Multipliers for Ex and Ez surface integrals; default values of 1.0
-    std::vector<amrex::Real> m_multiplier_vector={1.0,1.0};
+    std::vector<amrex::Real> m_scaling_factor={1.0,1.0};
 #else
     // The direction of the surface for surface integration. (e.g. X, Y, or Z)
     int m_surface_normal[3]={0,0,0};
     // Multipliers for Ex, Ey, and Ez surface integrals; default values of 1.0
-    std::vector<amrex::Real> m_multiplier_vector={1.0,1.0,1.0};
+    std::vector<amrex::Real> m_scaling_factor={1.0,1.0,1.0};
 #endif
 
 public:
@@ -266,14 +266,14 @@ public:
                 } else {
 #if (AMREX_SPACEDIM==2)
                 amrex::Real length = surface_normal[0]*dx[1] + surface_normal[1]*dx[0];
-                reducedEx_value *= m_multiplier_vector[0]*length;
+                reducedEx_value *= m_scaling_factor[0]*length;
                 reducedEy_value *= length;
-                reducedEz_value *= m_multiplier_vector[1]*length;
+                reducedEz_value *= m_scaling_factor[1]*length;
 #else
                 amrex::Real area = surface_normal[0]*dx[1]*dx[2] + surface_normal[1]*dx[2]*dx[0] + surface_normal[2]*dx[0]*dx[1];
-                reducedEx_value *= m_multiplier_vector[0]*area;
-                reducedEy_value *= m_multiplier_vector[1]*area;
-                reducedEz_value *= m_multiplier_vector[2]*area;
+                reducedEx_value *= m_scaling_factor[0]*area;
+                reducedEy_value *= m_scaling_factor[1]*area;
+                reducedEz_value *= m_scaling_factor[2]*area;
 #endif
                 }
             }

--- a/Source/Diagnostics/ReducedDiags/RawEFieldReduction.cpp
+++ b/Source/Diagnostics/ReducedDiags/RawEFieldReduction.cpp
@@ -84,6 +84,11 @@ RawEFieldReduction::RawEFieldReduction (std::string rd_name)
             m_surface_normal[2] = 1;
         }
     #endif
+        for (int i=0; i < AMREX_SPACEDIM; ++i) {
+            m_multiplier_vector[i] = 1;
+        }
+        pp_rd_name.queryarr("multiplier_vector", m_multiplier_vector, 0, AMREX_SPACEDIM);
+        AMREX_ASSERT(m_multiplier_vector.size() == AMREX_SPACEDIM);
     }
 
     if (amrex::ParallelDescriptor::IOProcessor())

--- a/Source/Diagnostics/ReducedDiags/RawEFieldReduction.cpp
+++ b/Source/Diagnostics/ReducedDiags/RawEFieldReduction.cpp
@@ -84,8 +84,8 @@ RawEFieldReduction::RawEFieldReduction (std::string rd_name)
             m_surface_normal[2] = 1;
         }
 #endif
-        pp_rd_name.queryarr("multiplier_vector", m_multiplier_vector, 0, AMREX_SPACEDIM);
-        AMREX_ASSERT(m_multiplier_vector.size() == AMREX_SPACEDIM);
+        pp_rd_name.queryarr("scaling_factor", m_scaling_factor, 0, AMREX_SPACEDIM);
+        AMREX_ASSERT(m_scaling_factor.size() == AMREX_SPACEDIM);
     }
 
     if (amrex::ParallelDescriptor::IOProcessor())

--- a/Source/Diagnostics/ReducedDiags/RawEFieldReduction.cpp
+++ b/Source/Diagnostics/ReducedDiags/RawEFieldReduction.cpp
@@ -63,7 +63,7 @@ RawEFieldReduction::RawEFieldReduction (std::string rd_name)
         m_integral_type = GetAlgorithmInteger (pp_rd_name, "integration_type");
     }
 
-    if (m_integral_type == IntegrationType::Surface) { 
+    if (m_integral_type == IntegrationType::Surface) {
         std::string surface_normal_string;
         pp_rd_name.get("surface_normal", surface_normal_string);
         if (surface_normal_string == "x" || surface_normal_string == "X") {

--- a/Source/Diagnostics/ReducedDiags/RawEFieldReduction.cpp
+++ b/Source/Diagnostics/ReducedDiags/RawEFieldReduction.cpp
@@ -84,9 +84,6 @@ RawEFieldReduction::RawEFieldReduction (std::string rd_name)
             m_surface_normal[2] = 1;
         }
     #endif
-        for (int i=0; i < AMREX_SPACEDIM; ++i) {
-            m_multiplier_vector[i] = 1;
-        }
         pp_rd_name.queryarr("multiplier_vector", m_multiplier_vector, 0, AMREX_SPACEDIM);
         AMREX_ASSERT(m_multiplier_vector.size() == AMREX_SPACEDIM);
     }

--- a/Source/Diagnostics/ReducedDiags/RawEFieldReduction.cpp
+++ b/Source/Diagnostics/ReducedDiags/RawEFieldReduction.cpp
@@ -63,7 +63,7 @@ RawEFieldReduction::RawEFieldReduction (std::string rd_name)
         m_integral_type = GetAlgorithmInteger (pp_rd_name, "integration_type");
     }
 
-    if (m_integral_type == 1) { //if integration_type=surface
+    if (m_integral_type == IntegrationType::Surface) { 
         std::string surface_normal_string;
         pp_rd_name.get("surface_normal", surface_normal_string);
         if (surface_normal_string == "x" || surface_normal_string == "X") {

--- a/Source/Diagnostics/ReducedDiags/RawEFieldReduction.cpp
+++ b/Source/Diagnostics/ReducedDiags/RawEFieldReduction.cpp
@@ -59,7 +59,7 @@ RawEFieldReduction::RawEFieldReduction (std::string rd_name)
     std::string reduction_type_string;
     pp_rd_name.get("reduction_type", reduction_type_string);
     m_reduction_type = GetAlgorithmInteger (pp_rd_name, "reduction_type");
-    if (m_reduction_type == 2) {
+    if (m_reduction_type == ReductionType::Sum) {
         m_integral_type = GetAlgorithmInteger (pp_rd_name, "integration_type");
     }
 

--- a/Source/Diagnostics/ReducedDiags/RawEFieldReduction.cpp
+++ b/Source/Diagnostics/ReducedDiags/RawEFieldReduction.cpp
@@ -63,7 +63,7 @@ RawEFieldReduction::RawEFieldReduction (std::string rd_name)
         m_integral_type = GetAlgorithmInteger (pp_rd_name, "integration_type");
     }
 
-    if (m_integral_type == 1) { //if surface integral
+    if (m_integral_type == 1) { //if integration_type=surface
         std::string surface_normal_string;
         pp_rd_name.get("surface_normal", surface_normal_string);
         if (surface_normal_string == "x" || surface_normal_string == "X") {

--- a/Source/Diagnostics/ReducedDiags/RawEFieldReduction.cpp
+++ b/Source/Diagnostics/ReducedDiags/RawEFieldReduction.cpp
@@ -59,30 +59,32 @@ RawEFieldReduction::RawEFieldReduction (std::string rd_name)
     std::string reduction_type_string;
     pp_rd_name.get("reduction_type", reduction_type_string);
     m_reduction_type = GetAlgorithmInteger (pp_rd_name, "reduction_type");
-    if (m_reduction_type == 2) {
+    if (m_reduction_type == 2) { //if integral
         m_integral_type = GetAlgorithmInteger (pp_rd_name, "integration_type");
     }
 
-    std::string surface_normal_string;
-    pp_rd_name.get("surface_normal", surface_normal_string);
-    if (surface_normal_string == "x" || surface_normal_string == "X") {
-        m_surface_normal[0] = 1;
+    if (m_integral_type == 1) { //if surface integral
+        std::string surface_normal_string;
+        pp_rd_name.get("surface_normal", surface_normal_string);
+        if (surface_normal_string == "x" || surface_normal_string == "X") {
+            m_surface_normal[0] = 1;
+        }
+    #if (AMREX_SPACEDIM==2)
+        else if (surface_normal_string == "y" || surface_normal_string == "Y") {
+            amrex::Abort("In 2-D, we compute over an X-Z plane. So the plane of interest for the surface integral is Z.");
+        }
+        else if (surface_normal_string == "z" || surface_normal_string == "Z") {
+            m_surface_normal[1] = 1;
+        }
+    #else
+        else if (surface_normal_string == "y" || surface_normal_string == "Y") {
+            m_surface_normal[1] = 1;
+        }
+        else if (surface_normal_string == "z" || surface_normal_string == "Z") {
+            m_surface_normal[2] = 1;
+        }
+    #endif
     }
-#if (AMREX_SPACEDIM==2)
-    else if (surface_normal_string == "y" || surface_normal_string == "Y") {
-        amrex::Abort("In 2-D, we compute over an X-Z plane. So the plane of interest for the surface integral is Z.");
-    }
-    else if (surface_normal_string == "z" || surface_normal_string == "Z") {
-        m_surface_normal[1] = 1;
-    }
-#else
-    else if (surface_normal_string == "y" || surface_normal_string == "Y") {
-        m_surface_normal[1] = 1;
-    }
-    else if (surface_normal_string == "z" || surface_normal_string == "Z") {
-        m_surface_normal[2] = 1;
-    }
-#endif
 
     if (amrex::ParallelDescriptor::IOProcessor())
     {

--- a/Source/Diagnostics/ReducedDiags/RawEFieldReduction.cpp
+++ b/Source/Diagnostics/ReducedDiags/RawEFieldReduction.cpp
@@ -69,21 +69,21 @@ RawEFieldReduction::RawEFieldReduction (std::string rd_name)
         if (surface_normal_string == "x" || surface_normal_string == "X") {
             m_surface_normal[0] = 1;
         }
-    #if (AMREX_SPACEDIM==2)
+#if (AMREX_SPACEDIM==2)
         else if (surface_normal_string == "y" || surface_normal_string == "Y") {
             amrex::Abort("In 2-D, we compute over an X-Z plane. So the plane of interest for the surface integral is Z.");
         }
         else if (surface_normal_string == "z" || surface_normal_string == "Z") {
             m_surface_normal[1] = 1;
         }
-    #else
+#else
         else if (surface_normal_string == "y" || surface_normal_string == "Y") {
             m_surface_normal[1] = 1;
         }
         else if (surface_normal_string == "z" || surface_normal_string == "Z") {
             m_surface_normal[2] = 1;
         }
-    #endif
+#endif
         pp_rd_name.queryarr("multiplier_vector", m_multiplier_vector, 0, AMREX_SPACEDIM);
         AMREX_ASSERT(m_multiplier_vector.size() == AMREX_SPACEDIM);
     }

--- a/Source/Diagnostics/ReducedDiags/RawEFieldReduction.cpp
+++ b/Source/Diagnostics/ReducedDiags/RawEFieldReduction.cpp
@@ -59,7 +59,7 @@ RawEFieldReduction::RawEFieldReduction (std::string rd_name)
     std::string reduction_type_string;
     pp_rd_name.get("reduction_type", reduction_type_string);
     m_reduction_type = GetAlgorithmInteger (pp_rd_name, "reduction_type");
-    if (m_reduction_type == 2) { //if integral
+    if (m_reduction_type == 2) { //if reduction_type=Integral (ReductionType::Sum)
         m_integral_type = GetAlgorithmInteger (pp_rd_name, "integration_type");
     }
 

--- a/Source/Diagnostics/ReducedDiags/RawEFieldReduction.cpp
+++ b/Source/Diagnostics/ReducedDiags/RawEFieldReduction.cpp
@@ -59,7 +59,7 @@ RawEFieldReduction::RawEFieldReduction (std::string rd_name)
     std::string reduction_type_string;
     pp_rd_name.get("reduction_type", reduction_type_string);
     m_reduction_type = GetAlgorithmInteger (pp_rd_name, "reduction_type");
-    if (m_reduction_type == 2) { //if reduction_type=Integral (ReductionType::Sum)
+    if (m_reduction_type == 2) {
         m_integral_type = GetAlgorithmInteger (pp_rd_name, "integration_type");
     }
 


### PR DESCRIPTION
This pull request is a modification to our recently merged pull request for calculation of E field surface integral.
Earlier version required specification of surface_normal not only for surface integral but also for volume integral. This was a mistake on my part. We do not need to define a surface normal for volume integral.
This is fixed. 

Also, a multiplier_vector is added for surface_integral.
We use this to specify 3 numbers which are multiplied to our final answer of surface integral of Ex, Ey, and Ez. This way we can account for surface integral for surface having normal in the negative direction or if we want to multiply our final answer by a constant number such as epsilon, etc.
Please see updated documentation.

