### PR TITLE
Fix LLG restart bug

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -86,6 +86,12 @@ FlushFormatCheckpoint::WriteToFile (
                      amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "My_fp"));
         VisMF::Write(warpx.getMfield_fp(lev, 2),
                      amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Mz_fp"));
+        VisMF::Write(warpx.getH_biasfield_fp(lev, 0),
+                     amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Hxbias_fp"));
+        VisMF::Write(warpx.getH_biasfield_fp(lev, 1),
+                     amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Hybias_fp"));
+        VisMF::Write(warpx.getH_biasfield_fp(lev, 2),
+                     amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Hzbias_fp"));
 #endif
 
         if (WarpX::fft_do_time_averaging)
@@ -143,6 +149,12 @@ FlushFormatCheckpoint::WriteToFile (
                          amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "My_cp"));
             VisMF::Write(warpx.getMfield_cp(lev, 2),
                          amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Mz_cp"));
+            VisMF::Write(warpx.getH_biasfield_cp(lev, 0),
+                         amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Hxbias_fp"));
+            VisMF::Write(warpx.getH_biasfield_cp(lev, 1),
+                         amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Hybias_fp"));
+            VisMF::Write(warpx.getH_biasfield_cp(lev, 2),
+                         amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Hzbias_fp"));
 #endif
 
             if (WarpX::fft_do_time_averaging)

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -276,13 +276,18 @@ WarpX::InitFromCheckpoint ()
                     amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Hy_fp"));
         VisMF::Read(*Hfield_fp[lev][2],
                     amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Hz_fp"));
-
         VisMF::Read(*Mfield_fp[lev][0],
                     amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Mx_fp"));
         VisMF::Read(*Mfield_fp[lev][1],
                     amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "My_fp"));
         VisMF::Read(*Mfield_fp[lev][2],
                     amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Mz_fp"));
+        VisMF::Read(*H_biasfield_fp[lev][0],
+                    amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Hxbias_fp"));
+        VisMF::Read(*H_biasfield_fp[lev][1],
+                    amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Hybias_fp"));
+        VisMF::Read(*H_biasfield_fp[lev][2],
+                    amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Hzbias_fp"));
 #endif
         if (WarpX::fft_do_time_averaging)
         {
@@ -340,6 +345,13 @@ WarpX::InitFromCheckpoint ()
                         amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "My_cp"));
             VisMF::Read(*Mfield_cp[lev][2],
                         amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Mz_cp"));
+
+            VisMF::Read(*H_biasfield_cp[lev][0],
+                        amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Hxbias_cp"));
+            VisMF::Read(*H_biasfield_cp[lev][1],
+                        amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Hybias_cp"));
+            VisMF::Read(*H_biasfield_cp[lev][2],
+                        amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Hzbias_cp"));
 #endif
             if (WarpX::fft_do_time_averaging)
             {


### PR DESCRIPTION


This PR solves Issue #78 
Below is the updated input file from Issue #78 with the right number of padded zeros 

[inputs_3d.txt](https://github.com/ECP-WarpX/artemis/files/8399522/inputs_3d.txt)

Here is the difference between restarted and non-restart Mfields
![Screenshot from 2022-04-01 09-39-30](https://user-images.githubusercontent.com/41089244/161306015-1622d338-9f4e-4bcf-8d71-20c6e81be641.png)
