### PR TITLE
Fix bug FillBoundaryH instead of FillBoundaryB

### DIFF
--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -717,7 +717,7 @@ WarpX::FillBoundaryH (int lev, PatchType patch_type, IntVect ng)
                 (patch_type == PatchType::fine) ? pml[lev]->GetH_fp() : pml[lev]->GetH_cp();
 
             pml[lev]->Exchange(mf_pml, mf, patch_type, do_pml_in_domain);
-            pml[lev]->FillBoundaryB(patch_type);
+            pml[lev]->FillBoundaryH(patch_type);
         }
     }
 


### PR DESCRIPTION
This PR fixes a FillBoundary bug for Hfield.
When calling fill boundary in pml, we had a FillBoundaryB instead of FillBoundaryH.