### PR TITLE
Fix: RTD urllib3

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,19 @@
 #
 # License: BSD-3-Clause-LBNL
 
-requirements_file: Docs/requirements.txt
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+   configuration: Docs/source/conf.py
+
+python:
+   install:
+   - requirements: Docs/requirements.txt
 
 formats:
   - htmlzip


### PR DESCRIPTION
Use a newer Ubuntu that ships a recent OpenSSL when building Sphinx with readthedocs (RTD). This migrates a broken dependency for urllib3 in version 3+.

Same as https://github.com/ECP-WarpX/WarpX/pull/3896