### PR TITLE
implement lumped capacitor and resistor

### DIFF
--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveE.cpp
@@ -152,15 +152,15 @@ void FiniteDifferenceSolver::MacroscopicEvolveECartesian (
     amrex::MultiFab* lumped_capacitor_z_mf = nullptr;
 
     if (use_lumped_resistor){
-        amrex::MultiFab& lumped_resistor_x_mf = macroscopic_properties->getlumped_resistor_x_mf();
-        amrex::MultiFab& lumped_resistor_y_mf = macroscopic_properties->getlumped_resistor_y_mf();
-        amrex::MultiFab& lumped_resistor_z_mf = macroscopic_properties->getlumped_resistor_z_mf();
+        lumped_resistor_x_mf = &macroscopic_properties->getlumped_resistor_x_mf();
+        lumped_resistor_y_mf = &macroscopic_properties->getlumped_resistor_y_mf();
+        lumped_resistor_z_mf = &macroscopic_properties->getlumped_resistor_z_mf();
     }
 
     if (use_lumped_capacitor){
-        amrex::MultiFab& lumped_capacitor_x_mf = macroscopic_properties->getlumped_capacitor_x_mf();
-        amrex::MultiFab& lumped_capacitor_y_mf = macroscopic_properties->getlumped_capacitor_y_mf();
-        amrex::MultiFab& lumped_capacitor_z_mf = macroscopic_properties->getlumped_capacitor_z_mf();
+        lumped_capacitor_x_mf = &macroscopic_properties->getlumped_capacitor_x_mf();
+        lumped_capacitor_y_mf = &macroscopic_properties->getlumped_capacitor_y_mf();
+        lumped_capacitor_z_mf = &macroscopic_properties->getlumped_capacitor_z_mf();
     }
 
 #ifndef WARPX_MAG_LLG
@@ -281,24 +281,16 @@ void FiniteDifferenceSolver::MacroscopicEvolveECartesian (
                                                                                     Ex_stag, macro_cr, i, j, k, scomp);
 
                 // Extra conductance term from a lumped resistor on Ex edges
-                amrex::Real extra_sigma = 0._rt;
-                if (use_lumped_resistor) {
-                    amrex::Real const R = resistor_x_arr(i,j,k);
-                    if (R != 0._rt) {
-                        // edge length along x over cross-section area
-                        extra_sigma = dx[0] / (dx[1]*dx[2]*R);
-                    }
-                }
-                amrex::Real fac1 = dt / epsilon_interp * (sigma_interp + extra_sigma);
+                amrex::Real const fac1 = (dt/epsilon_interp) * 
+                                         ( sigma_interp + ((use_lumped_resistor && resistor_x_arr(i,j,k)!=0._rt)
+                                            ? dx[0] / (dx[1]*dx[2]*resistor_x_arr(i,j,k)) 
+                                            : 0._rt) );
 
-                amrex::Real fac2 = 0._rt;
-                if (use_lumped_capacitor) {
-                    amrex::Real const C = capacitor_x_arr(i,j,k);
-                    if (C != 0._rt) {
-                        fac2 = C * dx[0] / (dx[1]*dx[2]*epsilon_interp);
-                    }
-                }
-                
+                // Extra term from a lumped capacitor on Ex edges
+                amrex::Real const fac2 = (use_lumped_capacitor && capacitor_x_arr(i,j,k)!=0._rt)
+                                            ? capacitor_x_arr(i,j,k) * dx[0] / (dx[1]*dx[2]*epsilon_interp)
+                                            : 0._rt;
+
                 amrex::Real alpha_compact = T_MacroAlgo::alpha_compact(fac1, fac2);
                 amrex::Real beta_compact = T_MacroAlgo::beta_compact(fac1, fac2);
 
@@ -325,22 +317,19 @@ void FiniteDifferenceSolver::MacroscopicEvolveECartesian (
                 amrex::Real const epsilon_interp = ablastr::coarsen::sample::Interp(eps_arr, epsilon_stag,
                                                                                     Ey_stag, macro_cr, i, j, k, scomp);
 
-                amrex::Real extra_sigma = 0._rt;
-                if (use_lumped_resistor) {
-                    amrex::Real const R = resistor_y_arr(i,j,k);
-                    if (R != 0._rt) {
-                        extra_sigma = dx[1] / (dx[0]*dx[2]*R);
-                    }
-                }
-                amrex::Real const fac1 = (dt/epsilon_interp) * (sigma_interp + extra_sigma);
+                // Extra conductance term from a lumped resistor on Ey edges
+                amrex::Real const fac1 = (dt/epsilon_interp) * 
+                                         ( sigma_interp + ((use_lumped_resistor && resistor_y_arr(i,j,k)!=0._rt)
+                                            ? dx[1] / (dx[0]*dx[2]*resistor_y_arr(i,j,k)) 
+                                            : 0._rt) );
+                // if (use_lumped_resistor && resistor_y_arr(i,j,k)!=0._rt){ 
+                //     printf("fac1=%f\n", fac1);
+                // }
 
-                amrex::Real fac2 = 0._rt;
-                if (use_lumped_capacitor) {
-                    amrex::Real const C = capacitor_y_arr(i,j,k);
-                    if (C != 0._rt) {
-                        fac2 = C * dx[1] / (dx[0]*dx[2]*epsilon_interp);
-                    }
-                }
+                // Extra term from a lumped capacitor on Ey edges
+                amrex::Real const fac2 = (use_lumped_capacitor && capacitor_y_arr(i,j,k)!=0._rt)
+                                            ? capacitor_y_arr(i,j,k) * dx[1] / (dx[0]*dx[2]*epsilon_interp)
+                                            : 0._rt;
 
                 amrex::Real alpha_compact = T_MacroAlgo::alpha_compact(fac1, fac2);
                 amrex::Real beta_compact = T_MacroAlgo::beta_compact(fac1, fac2);
@@ -363,22 +352,16 @@ void FiniteDifferenceSolver::MacroscopicEvolveECartesian (
                 amrex::Real const epsilon_interp = ablastr::coarsen::sample::Interp(eps_arr, epsilon_stag,
                                                                                     Ez_stag, macro_cr, i, j, k, scomp);
 
-                amrex::Real extra_sigma = 0._rt;
-                if (use_lumped_resistor) {
-                    amrex::Real const R = resistor_z_arr(i,j,k);
-                    if (R != 0._rt) {
-                        extra_sigma = dx[2] / (dx[0]*dx[1]*R);
-                    }
-                }
-                amrex::Real const fac1 = (dt/epsilon_interp) * (sigma_interp + extra_sigma);
-
-                amrex::Real fac2 = 0._rt;
-                if (use_lumped_capacitor) {
-                    amrex::Real const C = capacitor_z_arr(i,j,k);
-                    if (C != 0._rt) {
-                        fac2 = C * dx[2] / (dx[0]*dx[1]*epsilon_interp);
-                    }
-                }
+                // Extra conductance term from a lumped resistor on Ez edges
+                amrex::Real const fac1 = (dt/epsilon_interp) * 
+                                         ( sigma_interp + ((use_lumped_resistor && resistor_z_arr(i,j,k)!=0._rt)
+                                            ? dx[2] / (dx[0]*dx[1]*resistor_z_arr(i,j,k)) 
+                                            : 0._rt) );
+                
+                // Extra term from a lumped capacitor on Ez edges
+                amrex::Real const fac2 = (use_lumped_capacitor && capacitor_z_arr(i,j,k)!=0._rt)
+                                            ? capacitor_z_arr(i,j,k) * dx[2] / (dx[0]*dx[1]*epsilon_interp)
+                                            : 0._rt;
                 
                 amrex::Real alpha_compact = T_MacroAlgo::alpha_compact(fac1, fac2);
                 amrex::Real beta_compact = T_MacroAlgo::beta_compact(fac1, fac2);

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveE.cpp
@@ -133,8 +133,36 @@ void FiniteDifferenceSolver::MacroscopicEvolveECartesian (
     amrex::ignore_unused(edge_lengths);
 #endif
 
+    auto &warpx = WarpX::GetInstance();
+
+    const int lev = 0;
+    const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = warpx.Geom(lev).CellSizeArray();
+
+    int use_lumped_resistor = warpx.use_lumped_resistor;
+    int use_lumped_capacitor = warpx.use_lumped_capacitor;
+
     amrex::MultiFab& sigma_mf = macroscopic_properties->getsigma_mf();
     amrex::MultiFab& epsilon_mf = macroscopic_properties->getepsilon_mf();
+
+    amrex::MultiFab* lumped_resistor_x_mf  = nullptr;
+    amrex::MultiFab* lumped_resistor_y_mf  = nullptr;
+    amrex::MultiFab* lumped_resistor_z_mf  = nullptr;
+    amrex::MultiFab* lumped_capacitor_x_mf = nullptr;
+    amrex::MultiFab* lumped_capacitor_y_mf = nullptr;
+    amrex::MultiFab* lumped_capacitor_z_mf = nullptr;
+
+    if (use_lumped_resistor){
+        amrex::MultiFab& lumped_resistor_x_mf = macroscopic_properties->getlumped_resistor_x_mf();
+        amrex::MultiFab& lumped_resistor_y_mf = macroscopic_properties->getlumped_resistor_y_mf();
+        amrex::MultiFab& lumped_resistor_z_mf = macroscopic_properties->getlumped_resistor_z_mf();
+    }
+
+    if (use_lumped_capacitor){
+        amrex::MultiFab& lumped_capacitor_x_mf = macroscopic_properties->getlumped_capacitor_x_mf();
+        amrex::MultiFab& lumped_capacitor_y_mf = macroscopic_properties->getlumped_capacitor_y_mf();
+        amrex::MultiFab& lumped_capacitor_z_mf = macroscopic_properties->getlumped_capacitor_z_mf();
+    }
+
 #ifndef WARPX_MAG_LLG
     amrex::MultiFab& mu_mf = macroscopic_properties->getmu_mf();
 #endif
@@ -144,6 +172,19 @@ void FiniteDifferenceSolver::MacroscopicEvolveECartesian (
     amrex::GpuArray<int, 3> const& sigma_stag = macroscopic_properties->sigma_IndexType;
     amrex::GpuArray<int, 3> const& epsilon_stag = macroscopic_properties->epsilon_IndexType;
     amrex::GpuArray<int, 3> const& macro_cr     = macroscopic_properties->macro_cr_ratio;
+
+    if (use_lumped_resistor){
+        amrex::GpuArray<int, 3> const& lumped_resistor_x_stag = macroscopic_properties->lumped_resistor_x_IndexType;
+        amrex::GpuArray<int, 3> const& lumped_resistor_y_stag = macroscopic_properties->lumped_resistor_y_IndexType;
+        amrex::GpuArray<int, 3> const& lumped_resistor_z_stag = macroscopic_properties->lumped_resistor_z_IndexType;
+    }
+
+    if (use_lumped_capacitor){
+        amrex::GpuArray<int, 3> const& lumped_capacitor_x_stag = macroscopic_properties->lumped_capacitor_x_IndexType;
+        amrex::GpuArray<int, 3> const& lumped_capacitor_y_stag = macroscopic_properties->lumped_capacitor_y_IndexType;
+        amrex::GpuArray<int, 3> const& lumped_capacitor_z_stag = macroscopic_properties->lumped_capacitor_z_IndexType;
+    }
+
     amrex::GpuArray<int, 3> const& Ex_stag = macroscopic_properties->Ex_IndexType;
     amrex::GpuArray<int, 3> const& Ey_stag = macroscopic_properties->Ey_IndexType;
     amrex::GpuArray<int, 3> const& Ez_stag = macroscopic_properties->Ez_IndexType;
@@ -176,6 +217,24 @@ void FiniteDifferenceSolver::MacroscopicEvolveECartesian (
         // material prop //
         amrex::Array4<amrex::Real> const& sigma_arr = sigma_mf.array(mfi);
         amrex::Array4<amrex::Real> const& eps_arr = epsilon_mf.array(mfi);
+
+        // Lumped element arrays (default-constructed; set only if feature enabled)
+        amrex::Array4<amrex::Real> resistor_x_arr, resistor_y_arr, resistor_z_arr;
+        amrex::Array4<amrex::Real> capacitor_x_arr, capacitor_y_arr, capacitor_z_arr;
+
+        if (use_lumped_resistor) {
+            // These produce lightweight views; safe to copy and capture by value
+            resistor_x_arr = lumped_resistor_x_mf->array(mfi);
+            resistor_y_arr = lumped_resistor_y_mf->array(mfi);
+            resistor_z_arr = lumped_resistor_z_mf->array(mfi);
+        }
+        if (use_lumped_capacitor) {
+            capacitor_x_arr = lumped_capacitor_x_mf->array(mfi);
+            capacitor_y_arr = lumped_capacitor_y_mf->array(mfi);
+            capacitor_z_arr = lumped_capacitor_z_mf->array(mfi);
+        }
+
+        
 #ifndef WARPX_MAG_LLG
         amrex::Array4<amrex::Real> const& mu_arr = mu_mf.array(mfi);
 #endif
@@ -220,12 +279,33 @@ void FiniteDifferenceSolver::MacroscopicEvolveECartesian (
                 // Interpolated permittivity, epsilon, to Ex position on the grid
                 amrex::Real const epsilon_interp = ablastr::coarsen::sample::Interp(eps_arr, epsilon_stag,
                                                                                     Ex_stag, macro_cr, i, j, k, scomp);
-                amrex::Real alpha = T_MacroAlgo::alpha( sigma_interp, epsilon_interp, dt);
-                amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt);
-                Ex(i, j, k) = alpha * Ex(i, j, k)
-                            + beta * ( - T_Algo::DownwardDz(Hy, coefs_z, n_coefs_z, i, j, k,0)
-                                       + T_Algo::DownwardDy(Hz, coefs_y, n_coefs_y, i, j, k,0)
-                                     ) - beta * jx(i, j, k);
+
+                // Extra conductance term from a lumped resistor on Ex edges
+                amrex::Real extra_sigma = 0._rt;
+                if (use_lumped_resistor) {
+                    amrex::Real const R = resistor_x_arr(i,j,k);
+                    if (R != 0._rt) {
+                        // edge length along x over cross-section area
+                        extra_sigma = dx[0] / (dx[1]*dx[2]*R);
+                    }
+                }
+                amrex::Real fac1 = dt / epsilon_interp * (sigma_interp + extra_sigma);
+
+                amrex::Real fac2 = 0._rt;
+                if (use_lumped_capacitor) {
+                    amrex::Real const C = capacitor_x_arr(i,j,k);
+                    if (C != 0._rt) {
+                        fac2 = C * dx[0] / (dx[1]*dx[2]*epsilon_interp);
+                    }
+                }
+                
+                amrex::Real alpha_compact = T_MacroAlgo::alpha_compact(fac1, fac2);
+                amrex::Real beta_compact = T_MacroAlgo::beta_compact(fac1, fac2);
+
+                Ex(i, j, k) = alpha_compact * Ex(i, j, k)
+                            + dt/epsilon_interp * beta_compact * ( - T_Algo::DownwardDz(Hy, coefs_z, n_coefs_z, i, j, k,0)
+                                       + T_Algo::DownwardDy(Hz, coefs_y, n_coefs_y, i, j, k,0)) 
+                            - dt/epsilon_interp * beta_compact * jx(i, j, k);
             },
 
             [=] AMREX_GPU_DEVICE (int i, int j, int k){
@@ -244,12 +324,31 @@ void FiniteDifferenceSolver::MacroscopicEvolveECartesian (
                 // Interpolated permittivity, epsilon, to Ey position on the grid
                 amrex::Real const epsilon_interp = ablastr::coarsen::sample::Interp(eps_arr, epsilon_stag,
                                                                                     Ey_stag, macro_cr, i, j, k, scomp);
-                amrex::Real alpha = T_MacroAlgo::alpha( sigma_interp, epsilon_interp, dt);
-                amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt);
-                Ey(i, j, k) = alpha * Ey(i, j, k)
-                            + beta * ( - T_Algo::DownwardDx(Hz, coefs_x, n_coefs_x, i, j, k,0)
-                                       + T_Algo::DownwardDz(Hx, coefs_z, n_coefs_z, i, j, k,0)
-                                     ) - beta * jy(i, j, k);
+
+                amrex::Real extra_sigma = 0._rt;
+                if (use_lumped_resistor) {
+                    amrex::Real const R = resistor_y_arr(i,j,k);
+                    if (R != 0._rt) {
+                        extra_sigma = dx[1] / (dx[0]*dx[2]*R);
+                    }
+                }
+                amrex::Real const fac1 = (dt/epsilon_interp) * (sigma_interp + extra_sigma);
+
+                amrex::Real fac2 = 0._rt;
+                if (use_lumped_capacitor) {
+                    amrex::Real const C = capacitor_y_arr(i,j,k);
+                    if (C != 0._rt) {
+                        fac2 = C * dx[1] / (dx[0]*dx[2]*epsilon_interp);
+                    }
+                }
+
+                amrex::Real alpha_compact = T_MacroAlgo::alpha_compact(fac1, fac2);
+                amrex::Real beta_compact = T_MacroAlgo::beta_compact(fac1, fac2);
+
+                Ey(i, j, k) = alpha_compact * Ey(i, j, k)
+                            + dt/epsilon_interp * beta_compact * ( - T_Algo::DownwardDx(Hz, coefs_x, n_coefs_x, i, j, k,0)
+                                       + T_Algo::DownwardDz(Hx, coefs_z, n_coefs_z, i, j, k,0)) 
+                            - dt/epsilon_interp * beta_compact * jy(i, j, k);
             },
 
             [=] AMREX_GPU_DEVICE (int i, int j, int k){
@@ -263,12 +362,31 @@ void FiniteDifferenceSolver::MacroscopicEvolveECartesian (
                 // Interpolated permittivity, epsilon, to Ez position on the grid
                 amrex::Real const epsilon_interp = ablastr::coarsen::sample::Interp(eps_arr, epsilon_stag,
                                                                                     Ez_stag, macro_cr, i, j, k, scomp);
-                amrex::Real alpha = T_MacroAlgo::alpha( sigma_interp, epsilon_interp, dt);
-                amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt);
-                Ez(i, j, k) = alpha * Ez(i, j, k)
-                            + beta * ( - T_Algo::DownwardDy(Hx, coefs_y, n_coefs_y, i, j, k,0)
-                                       + T_Algo::DownwardDx(Hy, coefs_x, n_coefs_x, i, j, k,0)
-                                     ) - beta * jz(i, j, k);
+
+                amrex::Real extra_sigma = 0._rt;
+                if (use_lumped_resistor) {
+                    amrex::Real const R = resistor_z_arr(i,j,k);
+                    if (R != 0._rt) {
+                        extra_sigma = dx[2] / (dx[0]*dx[1]*R);
+                    }
+                }
+                amrex::Real const fac1 = (dt/epsilon_interp) * (sigma_interp + extra_sigma);
+
+                amrex::Real fac2 = 0._rt;
+                if (use_lumped_capacitor) {
+                    amrex::Real const C = capacitor_z_arr(i,j,k);
+                    if (C != 0._rt) {
+                        fac2 = C * dx[2] / (dx[0]*dx[1]*epsilon_interp);
+                    }
+                }
+                
+                amrex::Real alpha_compact = T_MacroAlgo::alpha_compact(fac1, fac2);
+                amrex::Real beta_compact = T_MacroAlgo::beta_compact(fac1, fac2);
+
+                Ez(i, j, k) = alpha_compact * Ez(i, j, k)
+                            + dt/epsilon_interp * beta_compact * ( - T_Algo::DownwardDy(Hx, coefs_y, n_coefs_y, i, j, k,0)
+                                       + T_Algo::DownwardDx(Hy, coefs_x, n_coefs_x, i, j, k,0)) 
+                            - dt/epsilon_interp * beta_compact * jz(i, j, k);
             }
         );
     }

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H
@@ -47,6 +47,20 @@ public:
      amrex::MultiFab& getmu_mf  () {return (*m_mu_mf);}
      amrex::MultiFab * get_pointer_mu () {return m_mu_mf.get();}
 
+     amrex::MultiFab& getlumped_resistor_x_mf () {return (*m_lumped_resistor_x_mf);}
+     amrex::MultiFab * get_pointer_lumped_resistor_x () {return m_lumped_resistor_x_mf.get();}
+     amrex::MultiFab& getlumped_resistor_y_mf () {return (*m_lumped_resistor_y_mf);}
+     amrex::MultiFab * get_pointer_lumped_resistor_y () {return m_lumped_resistor_y_mf.get();}
+     amrex::MultiFab& getlumped_resistor_z_mf () {return (*m_lumped_resistor_z_mf);}
+     amrex::MultiFab * get_pointer_lumped_resistor_z () {return m_lumped_resistor_z_mf.get();}
+
+     amrex::MultiFab& getlumped_capacitor_x_mf () {return (*m_lumped_capacitor_x_mf);}
+     amrex::MultiFab * get_pointer_lumped_capacitor_x () {return m_lumped_capacitor_x_mf.get();}
+     amrex::MultiFab& getlumped_capacitor_y_mf () {return (*m_lumped_capacitor_y_mf);}
+     amrex::MultiFab * get_pointer_lumped_capacitor_y () {return m_lumped_capacitor_y_mf.get();}
+     amrex::MultiFab& getlumped_capacitor_z_mf () {return (*m_lumped_capacitor_z_mf);}
+     amrex::MultiFab * get_pointer_lumped_capacitor_z () {return m_lumped_capacitor_z_mf.get();}
+
      /** Gpu Vector with index type of coarsening ratio with default value (1,1,1) */
      amrex::GpuArray<int, 3> macro_cr_ratio;
      /** Initializes the Multifabs storing macroscopic properties
@@ -61,7 +75,7 @@ public:
                                            const int lev,
                                            const int npy_k_index,
                                            const amrex::Real npy_value);
-    
+
     void InitializePECFromSigma (amrex::MultiFab* sigma_mf,
                                  amrex::MultiFab* PECx,
                                  amrex::MultiFab* PECy,
@@ -73,6 +87,14 @@ public:
      amrex::GpuArray<int, 3> epsilon_IndexType;
      /** Gpu Vector with index type of the permeability multifab */
      amrex::GpuArray<int, 3> mu_IndexType;
+     /** Gpu Vector with index type of the lumped resistor multifab */
+     amrex::GpuArray<int, 3> lumped_resistor_x_IndexType;
+     amrex::GpuArray<int, 3> lumped_resistor_y_IndexType;
+     amrex::GpuArray<int, 3> lumped_resistor_z_IndexType;
+     /** Gpu Vector with index type of the lumped capacitor multifab */
+     amrex::GpuArray<int, 3> lumped_capacitor_x_IndexType;
+     amrex::GpuArray<int, 3> lumped_capacitor_y_IndexType;
+     amrex::GpuArray<int, 3> lumped_capacitor_z_IndexType;
      /** Gpu Vector with index type of the Ex multifab */
      amrex::GpuArray<int, 3> Ex_IndexType;
      /** Gpu Vector with index type of the Ey multifab */
@@ -85,6 +107,12 @@ public:
      amrex::GpuArray<int, 3> By_IndexType;
      /** Gpu Vector with index type of the Bz multifab */
      amrex::GpuArray<int, 3> Bz_IndexType;
+     /** Gpu Vector with index type of the jx multifab */
+     amrex::GpuArray<int, 3> jx_IndexType;
+     /** Gpu Vector with index type of the jy multifab */
+     amrex::GpuArray<int, 3> jy_IndexType;
+     /** Gpu Vector with index type of the jz multifab */
+     amrex::GpuArray<int, 3> jz_IndexType;
 
      /** Stores initialization type for conductivity : constant or parser */
      std::string m_sigma_s = "constant";
@@ -112,6 +140,12 @@ public:
      std::unique_ptr<amrex::Parser> m_sigma_parser;
      std::unique_ptr<amrex::Parser> m_epsilon_parser;
      std::unique_ptr<amrex::Parser> m_mu_parser;
+     std::unique_ptr<amrex::Parser> m_lumped_resistor_x_parser;
+     std::unique_ptr<amrex::Parser> m_lumped_resistor_y_parser;
+     std::unique_ptr<amrex::Parser> m_lumped_resistor_z_parser;
+     std::unique_ptr<amrex::Parser> m_lumped_capacitor_x_parser;
+     std::unique_ptr<amrex::Parser> m_lumped_capacitor_y_parser;
+     std::unique_ptr<amrex::Parser> m_lumped_capacitor_z_parser;
 
 #ifdef WARPX_MAG_LLG
      /** Gpu Vector with index type of the Hx multifab */
@@ -320,11 +354,25 @@ private:
      /** Multifab for m_mu */
      std::unique_ptr<amrex::MultiFab> m_mu_mf;
 
+     /** Multifab for lumped resistor */
+     std::unique_ptr<amrex::MultiFab> m_lumped_resistor_x_mf;
+     std::unique_ptr<amrex::MultiFab> m_lumped_resistor_y_mf;
+     std::unique_ptr<amrex::MultiFab> m_lumped_resistor_z_mf;
+     /** Multifab for lumped capacitor */
+     std::unique_ptr<amrex::MultiFab> m_lumped_capacitor_x_mf;
+     std::unique_ptr<amrex::MultiFab> m_lumped_capacitor_y_mf;
+     std::unique_ptr<amrex::MultiFab> m_lumped_capacitor_z_mf;
 
      /** string for storing parser function */
      std::string m_str_sigma_function;
      std::string m_str_epsilon_function;
      std::string m_str_mu_function;
+     std::string m_str_lumped_resistor_x_function;
+     std::string m_str_lumped_resistor_y_function;
+     std::string m_str_lumped_resistor_z_function;
+     std::string m_str_lumped_capacitor_x_function;
+     std::string m_str_lumped_capacitor_y_function;
+     std::string m_str_lumped_capacitor_z_function;
 
 };
 
@@ -358,6 +406,22 @@ struct LaxWendroffAlgo {
          return beta;
      }
 
+     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+     static amrex::Real alpha_compact (amrex::Real const fac1,
+                               amrex::Real const fac2) {
+         using namespace amrex;
+         amrex::Real alpha_compact = (1._rt - 0.5_rt * fac1 + fac2)/(1._rt + 0.5_rt * fac1 + fac2);
+         return alpha_compact;
+     }
+
+     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+     static amrex::Real beta_compact (amrex::Real const fac1,
+                              amrex::Real const fac2) {
+         using namespace amrex;
+         amrex::Real beta_compact = 1._rt /  (1._rt + 0.5_rt * fac1 + fac2);
+         return beta_compact;
+     }
+
 };
 
 /**
@@ -388,6 +452,22 @@ struct BackwardEulerAlgo {
          amrex::Real fac1 = sigma * dt / epsilon;
          amrex::Real beta = dt / ( epsilon * (1._rt + fac1) );
          return beta;
+     }
+
+     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+     static amrex::Real alpha_compact (amrex::Real const fac1,
+                               amrex::Real const fac2) {
+         using namespace amrex;
+         amrex::Real alpha_compact = (1._rt + fac2)/(1._rt + fac1 + fac2);
+         return alpha_compact;
+     }
+
+     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+     static amrex::Real beta_compact (amrex::Real const fac1,
+                              amrex::Real const fac2) {
+         using namespace amrex;
+         amrex::Real beta_compact = 1._rt / (1._rt + fac1 + fac2);
+         return beta_compact;
      }
 
 };

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H
@@ -47,20 +47,20 @@ public:
      amrex::MultiFab& getmu_mf  () {return (*m_mu_mf);}
      amrex::MultiFab * get_pointer_mu () {return m_mu_mf.get();}
 
-     amrex::MultiFab& getlumped_resistor_x_mf () {return (*m_lumped_resistor_x_mf);}
-     amrex::MultiFab * get_pointer_lumped_resistor_x () {return m_lumped_resistor_x_mf.get();}
-     amrex::MultiFab& getlumped_resistor_y_mf () {return (*m_lumped_resistor_y_mf);}
-     amrex::MultiFab * get_pointer_lumped_resistor_y () {return m_lumped_resistor_y_mf.get();}
-     amrex::MultiFab& getlumped_resistor_z_mf () {return (*m_lumped_resistor_z_mf);}
-     amrex::MultiFab * get_pointer_lumped_resistor_z () {return m_lumped_resistor_z_mf.get();}
-
-     amrex::MultiFab& getlumped_capacitor_x_mf () {return (*m_lumped_capacitor_x_mf);}
-     amrex::MultiFab * get_pointer_lumped_capacitor_x () {return m_lumped_capacitor_x_mf.get();}
-     amrex::MultiFab& getlumped_capacitor_y_mf () {return (*m_lumped_capacitor_y_mf);}
-     amrex::MultiFab * get_pointer_lumped_capacitor_y () {return m_lumped_capacitor_y_mf.get();}
-     amrex::MultiFab& getlumped_capacitor_z_mf () {return (*m_lumped_capacitor_z_mf);}
-     amrex::MultiFab * get_pointer_lumped_capacitor_z () {return m_lumped_capacitor_z_mf.get();}
-
+    amrex::MultiFab& getlumped_resistor_x_mf () {return (*m_lumped_resistor_x_mf);}
+    amrex::MultiFab * get_pointer_lumped_resistor_x () {return m_lumped_resistor_x_mf.get();}
+    amrex::MultiFab& getlumped_resistor_y_mf () {return (*m_lumped_resistor_y_mf);}
+    amrex::MultiFab * get_pointer_lumped_resistor_y () {return m_lumped_resistor_y_mf.get();}
+    amrex::MultiFab& getlumped_resistor_z_mf () {return (*m_lumped_resistor_z_mf);}
+    amrex::MultiFab * get_pointer_lumped_resistor_z () {return m_lumped_resistor_z_mf.get();}
+     
+    amrex::MultiFab& getlumped_capacitor_x_mf () {return (*m_lumped_capacitor_x_mf);}
+    amrex::MultiFab * get_pointer_lumped_capacitor_x () {return m_lumped_capacitor_x_mf.get();}
+    amrex::MultiFab& getlumped_capacitor_y_mf () {return (*m_lumped_capacitor_y_mf);}
+    amrex::MultiFab * get_pointer_lumped_capacitor_y () {return m_lumped_capacitor_y_mf.get();}
+    amrex::MultiFab& getlumped_capacitor_z_mf () {return (*m_lumped_capacitor_z_mf);}
+    amrex::MultiFab * get_pointer_lumped_capacitor_z () {return m_lumped_capacitor_z_mf.get();}
+     
      /** Gpu Vector with index type of coarsening ratio with default value (1,1,1) */
      amrex::GpuArray<int, 3> macro_cr_ratio;
      /** Initializes the Multifabs storing macroscopic properties
@@ -87,14 +87,17 @@ public:
      amrex::GpuArray<int, 3> epsilon_IndexType;
      /** Gpu Vector with index type of the permeability multifab */
      amrex::GpuArray<int, 3> mu_IndexType;
-     /** Gpu Vector with index type of the lumped resistor multifab */
-     amrex::GpuArray<int, 3> lumped_resistor_x_IndexType;
-     amrex::GpuArray<int, 3> lumped_resistor_y_IndexType;
-     amrex::GpuArray<int, 3> lumped_resistor_z_IndexType;
-     /** Gpu Vector with index type of the lumped capacitor multifab */
-     amrex::GpuArray<int, 3> lumped_capacitor_x_IndexType;
-     amrex::GpuArray<int, 3> lumped_capacitor_y_IndexType;
-     amrex::GpuArray<int, 3> lumped_capacitor_z_IndexType;
+     
+    /** Gpu Vector with index type of the lumped resistor multifab */
+    amrex::GpuArray<int, 3> lumped_resistor_x_IndexType;
+    amrex::GpuArray<int, 3> lumped_resistor_y_IndexType;
+    amrex::GpuArray<int, 3> lumped_resistor_z_IndexType;
+
+    /** Gpu Vector with index type of the lumped capacitor multifab */
+    amrex::GpuArray<int, 3> lumped_capacitor_x_IndexType;
+    amrex::GpuArray<int, 3> lumped_capacitor_y_IndexType;
+    amrex::GpuArray<int, 3> lumped_capacitor_z_IndexType;
+
      /** Gpu Vector with index type of the Ex multifab */
      amrex::GpuArray<int, 3> Ex_IndexType;
      /** Gpu Vector with index type of the Ey multifab */
@@ -140,12 +143,15 @@ public:
      std::unique_ptr<amrex::Parser> m_sigma_parser;
      std::unique_ptr<amrex::Parser> m_epsilon_parser;
      std::unique_ptr<amrex::Parser> m_mu_parser;
-     std::unique_ptr<amrex::Parser> m_lumped_resistor_x_parser;
-     std::unique_ptr<amrex::Parser> m_lumped_resistor_y_parser;
-     std::unique_ptr<amrex::Parser> m_lumped_resistor_z_parser;
-     std::unique_ptr<amrex::Parser> m_lumped_capacitor_x_parser;
-     std::unique_ptr<amrex::Parser> m_lumped_capacitor_y_parser;
-     std::unique_ptr<amrex::Parser> m_lumped_capacitor_z_parser;
+
+    std::unique_ptr<amrex::Parser> m_lumped_resistor_x_parser;
+    std::unique_ptr<amrex::Parser> m_lumped_resistor_y_parser;
+    std::unique_ptr<amrex::Parser> m_lumped_resistor_z_parser;
+
+    std::unique_ptr<amrex::Parser> m_lumped_capacitor_x_parser;
+    std::unique_ptr<amrex::Parser> m_lumped_capacitor_y_parser;
+    std::unique_ptr<amrex::Parser> m_lumped_capacitor_z_parser;
+     
 
 #ifdef WARPX_MAG_LLG
      /** Gpu Vector with index type of the Hx multifab */
@@ -354,25 +360,28 @@ private:
      /** Multifab for m_mu */
      std::unique_ptr<amrex::MultiFab> m_mu_mf;
 
-     /** Multifab for lumped resistor */
-     std::unique_ptr<amrex::MultiFab> m_lumped_resistor_x_mf;
-     std::unique_ptr<amrex::MultiFab> m_lumped_resistor_y_mf;
-     std::unique_ptr<amrex::MultiFab> m_lumped_resistor_z_mf;
-     /** Multifab for lumped capacitor */
-     std::unique_ptr<amrex::MultiFab> m_lumped_capacitor_x_mf;
-     std::unique_ptr<amrex::MultiFab> m_lumped_capacitor_y_mf;
-     std::unique_ptr<amrex::MultiFab> m_lumped_capacitor_z_mf;
+    /** Multifab for lumped resistor */
+    std::unique_ptr<amrex::MultiFab> m_lumped_resistor_x_mf;
+    std::unique_ptr<amrex::MultiFab> m_lumped_resistor_y_mf;
+    std::unique_ptr<amrex::MultiFab> m_lumped_resistor_z_mf;
+    /** string for storing parser function */
+    std::string m_str_lumped_resistor_x_function;
+    std::string m_str_lumped_resistor_y_function;
+    std::string m_str_lumped_resistor_z_function;
 
+    /** Multifab for lumped capacitor */
+    std::unique_ptr<amrex::MultiFab> m_lumped_capacitor_x_mf;
+    std::unique_ptr<amrex::MultiFab> m_lumped_capacitor_y_mf;
+    std::unique_ptr<amrex::MultiFab> m_lumped_capacitor_z_mf;
+    /** string for storing parser function */
+    std::string m_str_lumped_capacitor_x_function;
+    std::string m_str_lumped_capacitor_y_function;
+    std::string m_str_lumped_capacitor_z_function;
+    
      /** string for storing parser function */
      std::string m_str_sigma_function;
      std::string m_str_epsilon_function;
      std::string m_str_mu_function;
-     std::string m_str_lumped_resistor_x_function;
-     std::string m_str_lumped_resistor_y_function;
-     std::string m_str_lumped_resistor_z_function;
-     std::string m_str_lumped_capacitor_x_function;
-     std::string m_str_lumped_capacitor_y_function;
-     std::string m_str_lumped_capacitor_z_function;
 
 };
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -363,22 +363,25 @@ MacroscopicProperties::InitData ()
         InitializeMacroMultiFabFromNumpy(m_mu_mf.get(), m_mu_npy_filename, lev, m_npy_k_index, m_mu_npy_value);
     }
 
-    m_lumped_resistor_x_mf = std::make_unique<amrex::MultiFab>(amrex::convert(ba,jx_stag), dmap, 1, ng_EB_alloc);
-    m_lumped_resistor_y_mf = std::make_unique<amrex::MultiFab>(amrex::convert(ba,jy_stag), dmap, 1, ng_EB_alloc);
-    m_lumped_resistor_z_mf = std::make_unique<amrex::MultiFab>(amrex::convert(ba,jz_stag), dmap, 1, ng_EB_alloc);
+    if (warpx.use_lumped_resistor == 1){
+        m_lumped_resistor_x_mf = std::make_unique<amrex::MultiFab>(amrex::convert(ba,jx_stag), dmap, 1, ng_EB_alloc);
+        m_lumped_resistor_y_mf = std::make_unique<amrex::MultiFab>(amrex::convert(ba,jy_stag), dmap, 1, ng_EB_alloc);
+        m_lumped_resistor_z_mf = std::make_unique<amrex::MultiFab>(amrex::convert(ba,jz_stag), dmap, 1, ng_EB_alloc);
 
-    InitializeMacroMultiFabUsingParser(m_lumped_resistor_x_mf.get(), m_lumped_resistor_x_parser->compile<3>(), lev);
-    InitializeMacroMultiFabUsingParser(m_lumped_resistor_y_mf.get(), m_lumped_resistor_y_parser->compile<3>(), lev);
-    InitializeMacroMultiFabUsingParser(m_lumped_resistor_z_mf.get(), m_lumped_resistor_z_parser->compile<3>(), lev);
+        InitializeMacroMultiFabUsingParser(m_lumped_resistor_x_mf.get(), m_lumped_resistor_x_parser->compile<3>(), lev);
+        InitializeMacroMultiFabUsingParser(m_lumped_resistor_y_mf.get(), m_lumped_resistor_y_parser->compile<3>(), lev);
+        InitializeMacroMultiFabUsingParser(m_lumped_resistor_z_mf.get(), m_lumped_resistor_z_parser->compile<3>(), lev);
+    }
 
-    m_lumped_capacitor_x_mf = std::make_unique<amrex::MultiFab>(amrex::convert(ba,jx_stag), dmap, 1, ng_EB_alloc);
-    m_lumped_capacitor_y_mf = std::make_unique<amrex::MultiFab>(amrex::convert(ba,jy_stag), dmap, 1, ng_EB_alloc);
-    m_lumped_capacitor_z_mf = std::make_unique<amrex::MultiFab>(amrex::convert(ba,jz_stag), dmap, 1, ng_EB_alloc);
+    if (warpx.use_lumped_capacitor == 1){
+        m_lumped_capacitor_x_mf = std::make_unique<amrex::MultiFab>(amrex::convert(ba,jx_stag), dmap, 1, ng_EB_alloc);
+        m_lumped_capacitor_y_mf = std::make_unique<amrex::MultiFab>(amrex::convert(ba,jy_stag), dmap, 1, ng_EB_alloc);
+        m_lumped_capacitor_z_mf = std::make_unique<amrex::MultiFab>(amrex::convert(ba,jz_stag), dmap, 1, ng_EB_alloc);
 
-    InitializeMacroMultiFabUsingParser(m_lumped_capacitor_x_mf.get(), m_lumped_capacitor_x_parser->compile<3>(), lev);
-    InitializeMacroMultiFabUsingParser(m_lumped_capacitor_y_mf.get(), m_lumped_capacitor_y_parser->compile<3>(), lev);
-    InitializeMacroMultiFabUsingParser(m_lumped_capacitor_z_mf.get(), m_lumped_capacitor_z_parser->compile<3>(), lev);
-
+        InitializeMacroMultiFabUsingParser(m_lumped_capacitor_x_mf.get(), m_lumped_capacitor_x_parser->compile<3>(), lev);
+        InitializeMacroMultiFabUsingParser(m_lumped_capacitor_y_mf.get(), m_lumped_capacitor_y_parser->compile<3>(), lev);
+        InitializeMacroMultiFabUsingParser(m_lumped_capacitor_z_mf.get(), m_lumped_capacitor_z_parser->compile<3>(), lev);
+    }
 
 #ifdef WARPX_MAG_LLG
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -36,6 +36,7 @@ MacroscopicProperties::MacroscopicProperties ()
 void
 MacroscopicProperties::ReadParameters ()
 {
+    auto &warpx = WarpX::GetInstance();
     ParmParse pp_macroscopic("macroscopic");
     // Since macroscopic maxwell solve is turned on,
     // user-defined sigma, mu, and epsilon are queried.
@@ -159,8 +160,37 @@ MacroscopicProperties::ReadParameters ()
             utils::parser::makeParser(m_str_mu_function,{"x","y","z"}));
     }
 
+
+    if (warpx.use_lumped_resistor == 1){
+        utils::parser::Store_parserString(pp_macroscopic, "lumped_resistor_x_function(x,y,z)", m_str_lumped_resistor_x_function);
+        m_lumped_resistor_x_parser = std::make_unique<amrex::Parser>(
+                                        utils::parser::makeParser(m_str_lumped_resistor_x_function,{"x","y","z"}));
+
+        utils::parser::Store_parserString(pp_macroscopic, "lumped_resistor_y_function(x,y,z)", m_str_lumped_resistor_y_function);
+        m_lumped_resistor_y_parser = std::make_unique<amrex::Parser>(
+                                        utils::parser::makeParser(m_str_lumped_resistor_y_function,{"x","y","z"}));
+
+        utils::parser::Store_parserString(pp_macroscopic, "lumped_resistor_z_function(x,y,z)", m_str_lumped_resistor_z_function);
+        m_lumped_resistor_z_parser = std::make_unique<amrex::Parser>(
+                                        utils::parser::makeParser(m_str_lumped_resistor_z_function,{"x","y","z"}));
+    }
+
+    if (warpx.use_lumped_capacitor == 1){
+        utils::parser::Store_parserString(pp_macroscopic, "lumped_capacitor_x_function(x,y,z)", m_str_lumped_capacitor_x_function);
+        m_lumped_capacitor_x_parser = std::make_unique<amrex::Parser>(
+                                        utils::parser::makeParser(m_str_lumped_capacitor_x_function,{"x","y","z"}));
+
+        utils::parser::Store_parserString(pp_macroscopic, "lumped_capacitor_y_function(x,y,z)", m_str_lumped_capacitor_y_function);
+        m_lumped_capacitor_y_parser = std::make_unique<amrex::Parser>(
+                                        utils::parser::makeParser(m_str_lumped_capacitor_y_function,{"x","y","z"}));
+
+        utils::parser::Store_parserString(pp_macroscopic, "lumped_capacitor_z_function(x,y,z)", m_str_lumped_capacitor_z_function);
+        m_lumped_capacitor_z_parser = std::make_unique<amrex::Parser>(
+                                        utils::parser::makeParser(m_str_lumped_capacitor_z_function,{"x","y","z"}));
+    }
+
 #ifdef WARPX_MAG_LLG
-    auto &warpx = WarpX::GetInstance();
+    // auto &warpx = WarpX::GetInstance();
     pp_macroscopic.get("mag_Ms_init_style", m_mag_Ms_s);
     if (m_mag_Ms_s == "constant") pp_macroscopic.get("mag_Ms", m_mag_Ms);
     // _mag_ such that it's clear the Ms variable is only meaningful for magnetic materials
@@ -246,6 +276,19 @@ MacroscopicProperties::InitData ()
     amrex::BoxArray ba = warpx.boxArray(lev);
     amrex::DistributionMapping dmap = warpx.DistributionMap(lev);
     const amrex::IntVect ng_EB_alloc = warpx.getngEB();
+
+    // lumped elements are defined on edges, so we get the index type of the current
+    // which is defined on edges
+    amrex::IntVect jx_stag = warpx.get_pointer_current_fp(lev,0)->ixType().toIntVect();
+    amrex::IntVect jy_stag = warpx.get_pointer_current_fp(lev,1)->ixType().toIntVect();
+    amrex::IntVect jz_stag = warpx.get_pointer_current_fp(lev,2)->ixType().toIntVect();
+
+    for ( int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+        jx_IndexType[idim] = jx_stag[idim];
+        jy_IndexType[idim] = jy_stag[idim];
+        jz_IndexType[idim] = jz_stag[idim];
+    }
+
     // Define material property multifabs using ba and dmap from WarpX instance
     // sigma is cell-centered MultiFab
     m_sigma_mf = std::make_unique<amrex::MultiFab>(ba, dmap, 1, ng_EB_alloc);
@@ -319,6 +362,23 @@ MacroscopicProperties::InitData ()
     if (m_mu_s == "parse_mu_npy_file" || m_mu_s == "parse_mu_both") {
         InitializeMacroMultiFabFromNumpy(m_mu_mf.get(), m_mu_npy_filename, lev, m_npy_k_index, m_mu_npy_value);
     }
+
+    m_lumped_resistor_x_mf = std::make_unique<amrex::MultiFab>(amrex::convert(ba,jx_stag), dmap, 1, ng_EB_alloc);
+    m_lumped_resistor_y_mf = std::make_unique<amrex::MultiFab>(amrex::convert(ba,jy_stag), dmap, 1, ng_EB_alloc);
+    m_lumped_resistor_z_mf = std::make_unique<amrex::MultiFab>(amrex::convert(ba,jz_stag), dmap, 1, ng_EB_alloc);
+
+    InitializeMacroMultiFabUsingParser(m_lumped_resistor_x_mf.get(), m_lumped_resistor_x_parser->compile<3>(), lev);
+    InitializeMacroMultiFabUsingParser(m_lumped_resistor_y_mf.get(), m_lumped_resistor_y_parser->compile<3>(), lev);
+    InitializeMacroMultiFabUsingParser(m_lumped_resistor_z_mf.get(), m_lumped_resistor_z_parser->compile<3>(), lev);
+
+    m_lumped_capacitor_x_mf = std::make_unique<amrex::MultiFab>(amrex::convert(ba,jx_stag), dmap, 1, ng_EB_alloc);
+    m_lumped_capacitor_y_mf = std::make_unique<amrex::MultiFab>(amrex::convert(ba,jy_stag), dmap, 1, ng_EB_alloc);
+    m_lumped_capacitor_z_mf = std::make_unique<amrex::MultiFab>(amrex::convert(ba,jz_stag), dmap, 1, ng_EB_alloc);
+
+    InitializeMacroMultiFabUsingParser(m_lumped_capacitor_x_mf.get(), m_lumped_capacitor_x_parser->compile<3>(), lev);
+    InitializeMacroMultiFabUsingParser(m_lumped_capacitor_y_mf.get(), m_lumped_capacitor_y_parser->compile<3>(), lev);
+    InitializeMacroMultiFabUsingParser(m_lumped_capacitor_z_mf.get(), m_lumped_capacitor_z_parser->compile<3>(), lev);
+
 
 #ifdef WARPX_MAG_LLG
 

--- a/Source/FieldSolver/LumpedElement/Inductor.cpp
+++ b/Source/FieldSolver/LumpedElement/Inductor.cpp
@@ -53,7 +53,7 @@ Inductor::InitData()
     amrex::DistributionMapping dmap = warpx.DistributionMap(lev);
     // number of guard cells used in EB solver
     const amrex::IntVect ng_EB_alloc = warpx.getngEB();
-    // Define a nodal multifab to store if region is on super conductor (1) or not (0)
+    // Define a nodal multifab to store if region has inductor (1) or not (0)
 
     amrex::IntVect jx_stag = warpx.get_pointer_current_fp(lev,0)->ixType().toIntVect();
     amrex::IntVect jy_stag = warpx.get_pointer_current_fp(lev,1)->ixType().toIntVect();

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -320,6 +320,8 @@ public:
 
     static int use_PEC_mask;
     static int use_lumped_inductor;
+    static int use_lumped_resistor;
+    static int use_lumped_capacitor;
     
     //! Integer that corresponds to the order of the PSATD solution
     //! (whether the PSATD equations are derived from first-order or

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -225,6 +225,8 @@ amrex::Vector<ParticleBoundaryType> WarpX::particle_boundary_hi(AMREX_SPACEDIM,P
 int WarpX::yee_coupled_solver_algo;
 int WarpX::use_PEC_mask = 0;
 int WarpX::use_lumped_inductor = 0;
+int WarpX::use_lumped_resistor = 0;
+int WarpX::use_lumped_capacitor = 0;
 
 bool WarpX::do_current_centering = false;
 
@@ -1032,6 +1034,9 @@ WarpX::ReadParameters ()
                 + " please set both parameters to the same value"
             );
         }
+
+        pp_warpx.query("use_lumped_resistor", use_lumped_resistor);
+        pp_warpx.query("use_lumped_capacitor", use_lumped_capacitor);    
 
 #ifdef WARPX_MAG_LLG
         // Read the value of the time advancement scheme of M field


### PR DESCRIPTION
This PR implemented lumped circuit components (inductor L, resistor R, and capacitor C) solving. 
The R, L and/or C are added on top of the physical materials & structures . The contribution of these lumped elements to current density `J` is added into Ampere's law:

`curl(H) = J_R + J_L + J_C + sigma*E + epsilon*dE/dt`

Lumped resistor is verified by a R-terminated microstrip transmission line (https://chemandy.com/calculators/microstrip-transmission-line-calculator.htm). The input file is


```

################################
####### GENERAL PARAMETERS ######
#################################
max_step = 200000

amr.n_cell = n_cellx n_celly n_cellz
amr.max_grid_size = max_grid_sizex max_grid_sizey max_grid_sizez
amr.blocking_factor = blocking_factor
amr.refine_grid_layout = 1  # if n_MPI > n_grids, the grids will be successively divided in half until n_MPI <= n_grids

geometry.dims = 3
geometry.prob_lo = prob_lox prob_loy prob_loz
geometry.prob_hi = prob_hix prob_hiy prob_hiz

amr.max_level = 0

# use pec instead of pml overlaying current source so you don't get a reflection
boundary.field_lo = pml pml pec
boundary.field_hi = pml pml pml

#################################
############ NUMERICS ###########
#################################
warpx.verbose = 1

warpx.cfl = 0.8

# ESSENTIAL! This extends PEC metal lines into the PML region to avoid artificial reflections.
warpx.Apply_E_excitation_in_pml_region=1

# vacuum or macroscopic
algo.em_solver_medium = macroscopic

# laxwendroff or backwardeuler
algo.macroscopic_sigma_method = laxwendroff

######################## IMPORTANT ######################
# the resistor and capcitor flag belongs to warpx class
warpx.use_lumped_resistor = 1
warpx.use_lumped_capacitor = 0
#########################################################

################ IMPORTANT ##############
# the inductor flag belongs to algo class
algo.use_lumped_inductor = 0
#########################################

#################################
############ STRUCTURE ###########
#################################

my_constants.h_si = 0.5e-3
my_constants.W_metal = 2.0e-3
my_constants.length = 100.0e-3

######################################################################
####### resistor and capacitor belongs to macroscopic class ##########
######################################################################
macroscopic.lumped_resistor_x_function(x,y,z) = "0."
macroscopic.lumped_resistor_y_function(x,y,z) = "0."
macroscopic.lumped_resistor_z_function(x,y,z) = "10.0 * (z >= 0) * (z < h_si) * (y > length-ddy) * (y < length+ddy) * (x < ddx) * (x > - ddx)"
# total inductance devided by number of cells in the z direction

macroscopic.epsilon_function(x,y,z) = "eps_0 + eps_0 * (eps_r_si - 1.) * (z <= h_si)"

macroscopic.mu_function(x,y,z) = "mu_0 + mu_0 * (mu_r_test - 1.) * (z > h_si ) * (z < h_si + dz) * (y < length + ddy)  * (x < W_metal/2 + ddx) * (x > -W_metal/2 - ddx)"

###############
# excitation
###############

warpx.E_excitation_on_grid_style = parse_E_excitation_grid_function

warpx.Ex_excitation_flag_function(x,y,z) = "flag_hs * (z > h_si - ddz) * (z < h_si + ddz) *
                                           (y < length + ddy)  * (x < W_metal/2 + ddx) * (x > -W_metal/2 - ddx)"

warpx.Ey_excitation_flag_function(x,y,z) = "flag_hs * (z > h_si - ddz) * (z < h_si + ddz) *
                                           (y < length + ddy)  * (x < W_metal/2 + ddx) * (x > -W_metal/2 - ddx)"
warpx.Ez_excitation_flag_function(x,y,z) = "flag_ss * (z >= 0) * (z < h_si) * (y > dy-ddy) * (y < dy+ddy) * (x < ddx) * (x > - ddx)"

# This is a source on a qubit control line
warpx.Ex_excitation_grid_function(x,y,z,t) = "0."
warpx.Ey_excitation_grid_function(x,y,z,t) = "0."
warpx.Ez_excitation_grid_function(x,y,z,t) = "exp(-(t-3*TP)**2/(2*TP**2))*sin(2*pi*freq*t)"


###############
# material properties
###############
my_constants.sigma_0 = 0.0
my_constants.sigma_si = 0.0
my_constants.sigma_metal = 1.e11

my_constants.eps_0 = 8.8541878128e-12
my_constants.eps_r_si = 3.0

my_constants.mu_0 = 1.25663706212e-06
my_constants.mu_r_si = 1.0
my_constants.mu_r_test = 0.999999

###############
# domain size
# n_cellx/y/z and Lx/y/z are needed to calculate dx/dy/dz
###############
my_constants.n_cellx = 100
my_constants.n_celly = 1200
my_constants.n_cellz = 40

my_constants.dx = 0.1e-3
my_constants.dy = 0.1e-3
my_constants.dz = 0.05e-3

# grid spacing
my_constants.dx = Lx / n_cellx
my_constants.dy = Ly / n_celly
my_constants.dz = Lz / n_cellz

my_constants.ddx = dx/1.e6
my_constants.ddy = dy/1.e6
my_constants.ddz = dz/1.e6

my_constants.max_grid_sizex = 50
my_constants.max_grid_sizey = 600
my_constants.max_grid_sizez = 40
my_constants.blocking_factor = 1

my_constants.prob_lox = -5.0e-3
my_constants.prob_loy = 0.0e-3
my_constants.prob_loz = 0.0

my_constants.prob_hix = 5.0e-3
my_constants.prob_hiy = 120.0e-3
my_constants.prob_hiz = 2.0e-3

my_constants.Lx = prob_hix - prob_lox
my_constants.Ly = prob_hiy - prob_loy
my_constants.Lz = prob_hiz - prob_loz

my_constants.flag_none = 0
my_constants.flag_hs = 1
my_constants.flag_ss = 2


###############
# derived quantities and fundamental constants 
###############

my_constants.pi = 3.14159265358979

my_constants.freq = 5.e9
my_constants.TP = 1./freq

###############
# diagnostics
###############

diagnostics.diags_names = plt
###############
# full plotfiles
plt.intervals = 20
plt.fields_to_plot = Ex Ey Ez Bx By Bz mu
plt.diag_type = Full
plt.file_min_digits = 7
```

The simulated input impedance matches analytical calculation:

<img width="1494" height="490" alt="image" src="https://github.com/user-attachments/assets/348c2950-c7d6-4b72-8ef0-9fd01a0413ac" />
<img width="1476" height="491" alt="image" src="https://github.com/user-attachments/assets/965a7b65-297b-4294-9e9c-301527d27fce" />
