### PR TITLE
fix restart with macroscopic properties

### DIFF
--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -408,6 +408,7 @@ WarpX::InitData ()
         }
         PostRestart();
         reduced_diags->InitData();
+        multi_diags->InitData();
     }
 
     ComputeMaxStep();


### PR DESCRIPTION
Restart now works if you try to plot mu, epsilon, or sigma after restart